### PR TITLE
tweaked boarder settings and cleared terminal

### DIFF
--- a/config/secretsSetupPrompt.go
+++ b/config/secretsSetupPrompt.go
@@ -2,11 +2,19 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
 
 	"github.com/charmbracelet/lipgloss"
+	"golang.org/x/term"
 )
 
 func SecretsSetupPrompt() {
+	clearTerminal()
+	// Get terminal width 
+	tw, _, _ := term.GetSize(int(os.Stdout.Fd()))
+
 	// Header box style
 	headerBoxStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("black")).
@@ -88,10 +96,22 @@ func SecretsSetupPrompt() {
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color("#51e2f5")).
-		Width(maxWidth + 2). // Adding some extra space for padding
+		Width(tw-2).
 		MarginTop(1).
 		MarginBottom(1)
 
 	// Render the box with centered content
 	fmt.Println(box.Render(lipgloss.JoinVertical(lipgloss.Center, header, body, footer)))
+}
+
+func clearTerminal() {
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.Command("cmd", "/c", "cls")
+	} else {
+		cmd = exec.Command("clear")
+	}
+
+	cmd.Stdout = os.Stdout
+	cmd.Run()
 }


### PR DESCRIPTION
Made border width set based on the width of the users terminal when they launch the application. This way if the users terminal isn't maxed out, it should still render normally 

Also, this is just a personal preference, but when I have visual elements that aren't just text (like a border) I like to have the console cleared to reduce clutter/visual noise. I added a clear terminal function (only when the user recieves instructions on configuring their client information) so that it will always look the same on launch. Since this is more of a personal thing, let me know if this change doesn't work for you and I can remove it. 
