### PR TITLE
Fix OAuth callback and startup race

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ To get started, you'll need a 'Client ID' and 'Client Secret' from Spotify's Dev
 
 6. 🌐 **Authenticate with Spotify**. In the Redirect URIs field of the app you created, please enter the following URLs:
 
-   - 📎 `http://localhost:4949/user-modify-playback-state-auth-callback`
-   - 📎 `http://localhost:4949/user-read-playback-state-auth-callback`
-   - 📎 `http://localhost:4949/user-library-read-auth-callback`
+   - 📎 `http://127.0.0.1:4949/user-modify-playback-state-auth-callback`
+   - 📎 `http://127.0.0.1:4949/user-read-playback-state-auth-callback`
+   - 📎 `http://127.0.0.1:4949/user-library-read-auth-callback`
 
 7. 🛍 **Once the App is created**, you'll find the 'Client ID' and 'Client Secret' on the app details page.
 

--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	projectName = "go-spotify-cli"
-	ServerUrl   = "http://localhost:4949"
+	ServerUrl   = "http://127.0.0.1:4949"
 )
 
 type Config struct {

--- a/server/server.go
+++ b/server/server.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"context"
+	"net"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/envoy49/go-spotify-cli/config"
@@ -46,6 +48,11 @@ func StartServer(cfg *config.Config, route string) context.CancelFunc {
 	ctx, cancel := context.WithCancel(context.Background())
 	go Server(ctx, cfg)
 
+	if err := waitForServerReady(); err != nil {
+		logrus.WithError(err).Error("Error waiting for the server to start")
+		return cancel
+	}
+
 	resp, err := http.Get(config.ServerUrl + route)
 	if err != nil {
 		logrus.WithError(err).Error("Error making the GET request to: " + route)
@@ -60,4 +67,25 @@ func StartServer(cfg *config.Config, route string) context.CancelFunc {
 	}()
 
 	return cancel
+}
+
+func waitForServerReady() error {
+	parsedURL, err := url.Parse(config.ServerUrl)
+	if err != nil {
+		return err
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", parsedURL.Host, 50*time.Millisecond)
+		if err == nil {
+			return conn.Close()
+		}
+		lastErr = err
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	return lastErr
 }


### PR DESCRIPTION
## Summary
- Switch Spotify redirect URI to 127.0.0.1 for local auth
- Wait for the auth server to be ready before triggering the callback
- Update README redirect URI examples

## Verification
- go test ./...